### PR TITLE
Test: Validate Terraform Apply Approval Gate

### DIFF
--- a/terraform/firewall.tf
+++ b/terraform/firewall.tf
@@ -7,6 +7,7 @@ resource "google_compute_firewall" "default_allow_http" {
   network     = "default" # Corresponds to the network URI in gcloud output
   direction   = "INGRESS"
   priority    = 1000
+  description = "Allow HTTP traffic from anywhere"
 
   allow {
     protocol = "tcp"
@@ -31,7 +32,7 @@ resource "google_compute_firewall" "default_allow_https" {
   }
 
   allow {
-    protocol = "udp" # Added for QUIC support as per gcloud output
+    protocol = "udp" # Added for QUIC support for HTTP 3
     ports    = ["443"]
   }
 


### PR DESCRIPTION
Introduces a minor, non-disruptive change (adding a description to the default_allow_http firewall rule) specifically to trigger and validate the newly implemented manual approval step in the Terraform CI/CD pipeline.

This commit on the 'terraform-dev' branch serves as the initial test case for the PR -> Plan -> Merge -> Approve -> Apply workflow, ensuring infrastructure changes require explicit sign-off before deployment to production (master).