### PR TITLE
feat: Implement Envoy edge HTTP-to-HTTPS redirection via Ansible

### DIFF
--- a/ansible/roles/envoy/templates/envoy.service.j2
+++ b/ansible/roles/envoy/templates/envoy.service.j2
@@ -1,8 +1,8 @@
-# {{ ansible_managed }} - Template: ~/src/gcc-ansible-wsl/ansible/roles/envoy/templates/envoy.service.j2
+# {{ ansible_managed }}
 [Unit]
 Description=Envoy Proxy Container (Host Network)
-Requires=docker.service network-online.target consul.service
-After=docker.service network-online.target consul.service
+Requires=docker.service network-online.target consul.service dnsmasq.service
+After=docker.service network-online.target consul.service dnsmasq.service
 
 [Service]
 Restart=always
@@ -15,11 +15,22 @@ ExecStartPre=-/bin/mkdir -p /etc/envoy
 ExecStartPre=-/usr/bin/docker stop envoy-svc
 ExecStartPre=-/usr/bin/docker rm envoy-svc
 
-# Pull the specified image (optional)
+# Pull the specified image
 ExecStartPre=-/usr/bin/docker pull {{ envoy_image_repository }}:{{ envoy_image_tag }}
 
 # Run the Envoy container using host networking - All on one line
-ExecStart=/usr/bin/docker run --rm --network host --name envoy-svc -v /etc/envoy/envoy.yaml:/etc/envoy/envoy.yaml:ro {{ envoy_image_repository }}:{{ envoy_image_tag }} -c /etc/envoy/envoy.yaml
+# Added -u root, --entrypoint, --cap-add, and other necessary args
+ExecStart=/usr/bin/docker run --rm --network host --name envoy-svc \
+  -u root \
+  --entrypoint "/usr/local/bin/envoy" \
+  --cap-add=NET_BIND_SERVICE \
+  -v /etc/envoy/envoy.yaml:/etc/envoy/envoy.yaml:ro \
+  -v /etc/letsencrypt:/etc/letsencrypt:ro \
+  {{ envoy_image_repository }}:{{ envoy_image_tag }} \
+  -c /etc/envoy/envoy.yaml \
+  --service-node edge-envoy-instance-1 \
+  --service-cluster grewalcc_services
+
 
 # Stop the container gracefully
 ExecStop=/usr/bin/docker stop envoy-svc

--- a/ansible/roles/envoy/templates/envoy.yaml.j2
+++ b/ansible/roles/envoy/templates/envoy.yaml.j2
@@ -53,7 +53,9 @@ static_resources:
                         allow_partial_message: true
                       http_service:
                         server_uri:
-                          uri: http://127.0.0.1:9001
+                          uri: |-
+                            http://127.0.0.1:{{authz_service_port
+                              | default(9001)}}
                           cluster: authz_cluster
                           timeout: 0.2s
                         path_prefix: "/authz"
@@ -88,6 +90,35 @@ static_resources:
                           route:
                             cluster: grewal_backend_cluster
                             timeout: 0s
+
+    - name: listener_http_redirect_to_https
+      address:
+        socket_address:
+          address: "{{envoy_listener_address}}"
+          port_value: 80
+      filter_chains:
+        - filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": |-
+                  type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: ingress_http_redirect
+                route_config:
+                  name: local_route_http_redirect
+                  virtual_hosts:
+                    - name: vh_redirect_all_to_https
+                      domains: ["*"]
+                      routes:
+                        - match: {prefix: "/"}
+                          redirect:
+                            https_redirect: true
+                            strip_query: false
+                            response_code: MOVED_PERMANENTLY
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": |-
+                        type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
   clusters:
     - name: grewal_backend_cluster
@@ -124,7 +155,7 @@ static_resources:
                   address:
                     socket_address:
                       address: gcc-gem-a.node.consul
-                      port_value: 9001
+                      port_value: "{{authz_service_port | default(9001)}}"
       typed_extension_protocol_options:
         envoy.extensions.upstreams.http.v3.HttpProtocolOptions:
           "@type": |-


### PR DESCRIPTION
This commit deploys the initial phase of replacing Nginx with Envoy as the edge proxy for grewal.cc. Envoy now handles incoming HTTP/80 requests and redirects them to HTTPS using a 301 `MOVED_PERMANENTLY` response.

Key configuration changes in `envoy.yaml.j2` include a new listener binding to `0.0.0.0:80` which utilizes the
`envoy.filters.http.router.v3.RedirectAction` with `https_redirect: true`.

The Ansible role for Envoy (`roles/envoy`) has been updated:
- `templates/envoy.yaml.j2` reflects the new redirect listener.
- `templates/envoy.service.j2` now ensures the Envoy Docker container is launched with appropriate permissions (`-u root`, `--entrypoint`) to bind to privileged port 80 when using host networking.

Functionality was verified by stopping Nginx, deploying via Ansible, and confirming successful 301 redirects for both external domain requests and local `127.0.0.1` requests.