### PR TITLE
feat(xds-adapter): Implement and validate static manifest-to-xDS gene…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,9 @@ yarn-error.log*
 *.tsbuildinfo
 next-env.d.ts
 /web/grewalcc-fluid-simulation/target/
+
+# Ignore generated Envoy configuration
+xds-adapter/generated-envoy.yaml
+
+# Ignore compiled Go binaries
+xds-adapter/xds-adapter

--- a/xds-adapter/go.mod
+++ b/xds-adapter/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/envoyproxy/go-control-plane/envoy v1.36.0 // indirect
 	github.com/envoyproxy/protoc-gen-validate v1.2.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/net v0.42.0 // indirect
 	golang.org/x/sys v0.34.0 // indirect
 	golang.org/x/text v0.27.0 // indirect
@@ -19,4 +20,5 @@ require (
 	google.golang.org/grpc v1.75.1 // indirect
 	google.golang.org/protobuf v1.36.10 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/xds-adapter/go.sum
+++ b/xds-adapter/go.sum
@@ -10,6 +10,8 @@ github.com/envoyproxy/protoc-gen-validate v1.2.1 h1:DEo3O99U8j4hBFwbJfrz9VtgcDfU
 github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 h1:GFCKgmp0tecUJ0sJuv4pzYCqS9+RGSn52M3FUwPs+uo=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
+go.yaml.in/yaml/v2 v2.4.2 h1:DzmwEr2rDGHl7lsFgAHxmNz/1NlQ7xLIrlN2h5d1eGI=
+go.yaml.in/yaml/v2 v2.4.2/go.mod h1:081UH+NErpNdqlCXm3TtEran0rJZGxAYx9hb/ELlsPU=
 golang.org/x/net v0.42.0 h1:jzkYrhi3YQWD6MLBJcsklgQsoAcw89EcZbJw8Z614hs=
 golang.org/x/net v0.42.0/go.mod h1:FF1RA5d3u7nAYA4z2TkclSCKh68eSXtiFwcWQpPXdt8=
 golang.org/x/sys v0.34.0 h1:H5Y5sJ2L2JRdyv7ROF1he/lPdvFsd0mJHFw2ThKHxLA=
@@ -27,3 +29,5 @@ google.golang.org/protobuf v1.36.10/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=
+sigs.k8s.io/yaml v1.6.0/go.mod h1:796bPqUfzR/0jLAl6XjHl3Ck7MiyVv8dbTdyT3/pMf4=

--- a/xds-adapter/main.go
+++ b/xds-adapter/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+
+	bootstrap "github.com/envoyproxy/go-control-plane/envoy/config/bootstrap/v3"
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	"google.golang.org/protobuf/encoding/protojson"
+	"sigs.k8s.io/yaml"
+)
+
+func main() {
+	// Define command-line flags for input and output files.
+	manifestPath := flag.String("manifest", "manifest.yaml", "Path to the input manifest.yaml file")
+	outputPath := flag.String("output", "generated-envoy.yaml", "Path to the output Envoy bootstrap file")
+	flag.Parse()
+
+	if *manifestPath == "" {
+		log.Fatalf("Error: --manifest flag cannot be empty")
+	}
+
+	// Read and parse the manifest file.
+	yamlFile, err := os.ReadFile(*manifestPath)
+	if err != nil {
+		log.Fatalf("Error reading manifest file %s: %v", *manifestPath, err)
+	}
+	manifest, err := ParseManifest(yamlFile)
+	if err != nil {
+		log.Fatalf("Error parsing manifest: %v", err)
+	}
+
+	// Run the manifest through our translation functions.
+	routeResources := makeRoutes(manifest.Routes)
+	clusterResources := makeClusters(manifest.Clusters)
+	listenerResources, err := makeListeners(manifest.Listeners, routeResources)
+	if err != nil {
+		log.Fatalf("Error generating listeners: %v", err)
+	}
+
+	// The Bootstrap object is the top-level configuration for Envoy.
+	config := &bootstrap.Bootstrap{
+		StaticResources: &bootstrap.Bootstrap_StaticResources{},
+	}
+
+	// Convert the generic []types.Resource slices to their concrete types.
+	for _, res := range listenerResources {
+		l, _ := res.(*listener.Listener)
+		config.StaticResources.Listeners = append(config.StaticResources.Listeners, l)
+	}
+	for _, res := range clusterResources {
+		c, _ := res.(*cluster.Cluster)
+		config.StaticResources.Clusters = append(config.StaticResources.Clusters, c)
+	}
+
+	// Marshal the bootstrap config using the Protobuf-aware JSON marshaller.
+	// This correctly omits empty fields like 'StatsEviction: null'.
+	jsonBytes, err := protojson.Marshal(config)
+	if err != nil {
+		log.Fatalf("Failed to marshal bootstrap config to JSON: %v", err)
+	}
+
+	// Convert the clean JSON to YAML.
+	yamlBytes, err := yaml.JSONToYAML(jsonBytes)
+	if err != nil {
+		log.Fatalf("Failed to convert JSON to YAML: %v", err)
+	}
+
+	// Write the final YAML to the specified output file.
+	err = os.WriteFile(*outputPath, yamlBytes, 0644)
+	if err != nil {
+		log.Fatalf("Failed to write output file %s: %v", *outputPath, err)
+	}
+
+	log.Printf("Successfully generated Envoy configuration at %s", *outputPath)
+}

--- a/xds-adapter/manifest.go
+++ b/xds-adapter/manifest.go
@@ -25,7 +25,6 @@ type TLS struct {
 }
 
 // Filter represents a network filter in an Envoy listener's filter chain.
-// This structure correctly models Envoy's architecture, separating different filter types.
 type Filter struct {
 	Type                  string                `yaml:"type"` // e.g., "network.rbac", "http_connection_manager"
 	RBAC                  *RBAC                 `yaml:"rbac,omitempty"`
@@ -101,8 +100,14 @@ type RouteMatch struct {
 
 // RouteAction specifies what to do when a route matches.
 type RouteAction struct {
-	Cluster        string `yaml:"cluster"`
-	TimeoutSeconds int    `yaml:"timeout_seconds,omitempty"`
+	Cluster        string    `yaml:"cluster,omitempty"`
+	TimeoutSeconds int       `yaml:"timeout_seconds,omitempty"`
+	Redirect       *Redirect `yaml:"redirect,omitempty"`
+}
+
+// Redirect defines an HTTP redirect action.
+type Redirect struct {
+	HttpsRedirect bool `yaml:"https_redirect"`
 }
 
 // Cluster defines an upstream service cluster, correctly using DNS for discovery.
@@ -110,6 +115,7 @@ type Cluster struct {
 	Name                  string `yaml:"name"`
 	ConnectTimeoutSeconds int    `yaml:"connect_timeout_seconds"`
 	Type                  string `yaml:"type"` // e.g., STRICT_DNS
+	DnsLookupFamily       string `yaml:"dns_lookup_family,omitempty"` // e.g., V4_ONLY
 	DNSName               string `yaml:"dns_name"`
 	Port                  uint32 `yaml:"port"`
 	IsHTTP2               bool   `yaml:"is_http2"`
@@ -122,5 +128,6 @@ func ParseManifest(data []byte) (*Manifest, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Here, we can add validation logic in the future.
 	return &m, nil
 }

--- a/xds-adapter/manifest.yaml
+++ b/xds-adapter/manifest.yaml
@@ -1,0 +1,111 @@
+# This manifest represents the full desired state for the Envoy proxy,
+# translated from the production envoy.yaml configuration.
+listeners:
+  - name: listener_https_main
+    address: "0.0.0.0"
+    port: 443
+    # Our translator doesn't handle TLS or advanced filters yet, but the schema supports them.
+    # We will uncomment these sections as we build out the translator logic.
+    # tls:
+    #   cert_chain_path: "/etc/letsencrypt/live/grewal.cc/fullchain.pem"
+    #   private_key_path: "/etc/letsencrypt/live/grewal.cc/privkey.pem"
+    #   alpn_protocols: ["h2", "http/1.1"]
+    filters:
+      # - type: "network.rbac"
+      #   rbac:
+      #     stat_prefix: "rbac_l3_ip_block"
+      #     policies:
+      #       - name: "static_ip_deny_list"
+      #         action: "DENY"
+      #         source_ips: ["73.92.2.75/32", "1.2.3.4/32"]
+      # - type: "network.ext_authz"
+      #   network_ext_authz:
+      #     stat_prefix: "ext_authz_network_l4"
+      #     grpc_cluster: "authz_network_grpc_cluster"
+      #     failure_mode_allow: false
+      - type: "http_connection_manager"
+        http_connection_manager:
+          stat_prefix: "ingress_https"
+          route_config_name: "grewalcc_website_routes"
+          # http_filters:
+          #   - type: "ext_authz"
+          #   - type: "grpc_web"
+          #   - type: "router"
+
+  - name: listener_http_redirect_to_https
+    address: "0.0.0.0"
+    port: 80
+    filters:
+      - type: "http_connection_manager"
+        http_connection_manager:
+          stat_prefix: "ingress_http_redirect"
+          route_config_name: "local_route_http_redirect"
+          # http_filters:
+          #   - type: "router"
+
+routes:
+  - name: grewalcc_website_routes
+    virtual_hosts:
+      - name: grewal_cc_virtual_host
+        domains: ["*"]
+        routes:
+          - match: { prefix: "/health" }
+            action: { cluster: "auth_service_cluster" }
+          - match: { prefix: "/metrics" }
+            action: { cluster: "auth_service_cluster" }
+          - match: { prefix: "/auth/" }
+            action: { cluster: "auth_service_cluster" }
+          - match: { prefix: "/grewal.HomeGeneral/" }
+            action: { cluster: "grewalcc_cluster" }
+          - match: { prefix: "/api/" }
+            action: { cluster: "nextjs-service-cluster" }
+          - match: { prefix: "/" }
+            action: { cluster: "nextjs-service-cluster" }
+
+  - name: local_route_http_redirect
+    virtual_hosts:
+      - name: vh_redirect_all_to_https
+        domains: ["*"]
+        routes:
+          - match: { prefix: "/" }
+            action:
+              redirect:
+                https_redirect: true
+
+clusters:
+  - name: grewalcc_cluster
+    connect_timeout_seconds: 5
+    type: STRICT_DNS
+    dns_lookup_family: V4_ONLY
+    dns_name: "grewalcc.service.consul"
+    port: 50051
+    is_http2: true
+
+  - name: authz_http_cluster
+    connect_timeout_seconds: 1 # 0.5s is not an int
+    type: STRICT_DNS
+    dns_lookup_family: V4_ONLY
+    dns_name: "host.docker.internal"
+    port: 9001
+
+  - name: authz_network_grpc_cluster
+    connect_timeout_seconds: 1 # 0.5s is not an int
+    type: STRICT_DNS
+    dns_lookup_family: V4_ONLY
+    dns_name: "host.docker.internal"
+    port: 9002
+    is_http2: true
+
+  - name: auth_service_cluster
+    connect_timeout_seconds: 1
+    type: STRICT_DNS
+    dns_lookup_family: V4_ONLY
+    dns_name: "auth-service"
+    port: 3000
+
+  - name: nextjs-service-cluster
+    connect_timeout_seconds: 5
+    type: STRICT_DNS
+    dns_lookup_family: V4_ONLY
+    dns_name: "grewal-cc-web"
+    port: 3000

--- a/xds-adapter/translator.go
+++ b/xds-adapter/translator.go
@@ -1,0 +1,223 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	cluster "github.com/envoyproxy/go-control-plane/envoy/config/cluster/v3"
+	core "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
+	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
+	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	router "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
+	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
+	cachev3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
+	resource "github.com/envoyproxy/go-control-plane/pkg/resource/v3"
+	"github.com/envoyproxy/go-control-plane/pkg/wellknown"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/durationpb"
+)
+
+// (generateSnapshot, makeClusters, makeRoutes are unchanged)
+
+func generateSnapshot(manifest *Manifest) (cachev3.Snapshot, error) {
+	const version = "1"
+	clusters := makeClusters(manifest.Clusters)
+	routes := makeRoutes(manifest.Routes)
+	listeners, err := makeListeners(manifest.Listeners, routes)
+	if err != nil {
+		return cachev3.Snapshot{}, fmt.Errorf("failed to create listeners: %w", err)
+	}
+	snapshot, err := cachev3.NewSnapshot(
+		version,
+		map[resource.Type][]types.Resource{
+			resource.ClusterType:  clusters,
+			resource.RouteType:    routes,
+			resource.ListenerType: listeners,
+		},
+	)
+	if err != nil {
+		return cachev3.Snapshot{}, fmt.Errorf("failed to create snapshot: %w", err)
+	}
+	return *snapshot, nil
+}
+func makeClusters(manifestClusters []Cluster) []types.Resource {
+	resources := make([]types.Resource, len(manifestClusters))
+	for i, mCluster := range manifestClusters {
+		dnsFamily := cluster.Cluster_AUTO
+		if mCluster.DnsLookupFamily == "V4_ONLY" {
+			dnsFamily = cluster.Cluster_V4_ONLY
+		}
+		c := &cluster.Cluster{
+			Name:                 mCluster.Name,
+			ConnectTimeout:       durationpb.New(time.Duration(mCluster.ConnectTimeoutSeconds) * time.Second),
+			ClusterDiscoveryType: &cluster.Cluster_Type{Type: cluster.Cluster_STRICT_DNS},
+			DnsLookupFamily:      dnsFamily,
+			LbPolicy:             cluster.Cluster_ROUND_ROBIN,
+			LoadAssignment: &endpoint.ClusterLoadAssignment{
+				ClusterName: mCluster.Name,
+				Endpoints: []*endpoint.LocalityLbEndpoints{
+					{
+						LbEndpoints: []*endpoint.LbEndpoint{
+							{
+								HostIdentifier: &endpoint.LbEndpoint_Endpoint{
+									Endpoint: &endpoint.Endpoint{
+										Address: &core.Address{
+											Address: &core.Address_SocketAddress{
+												SocketAddress: &core.SocketAddress{
+													Address:       mCluster.DNSName,
+													PortSpecifier: &core.SocketAddress_PortValue{PortValue: mCluster.Port},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		if mCluster.IsHTTP2 {
+			c.Http2ProtocolOptions = &core.Http2ProtocolOptions{}
+		}
+		resources[i] = c
+	}
+	return resources
+}
+func makeRoutes(manifestRoutes []RouteConfig) []types.Resource {
+	resources := make([]types.Resource, len(manifestRoutes))
+	for i, mRouteConfig := range manifestRoutes {
+		var virtualHosts []*route.VirtualHost
+		for _, mVh := range mRouteConfig.VirtualHosts {
+			var routes []*route.Route
+			for _, mRoute := range mVh.Routes {
+				r := &route.Route{
+					Match: &route.RouteMatch{
+						PathSpecifier: &route.RouteMatch_Prefix{Prefix: mRoute.Match.Prefix},
+					},
+				}
+
+				if mRoute.Action.Redirect != nil {
+					r.Action = &route.Route_Redirect{
+						Redirect: &route.RedirectAction{
+							SchemeRewriteSpecifier: &route.RedirectAction_HttpsRedirect{
+								HttpsRedirect: mRoute.Action.Redirect.HttpsRedirect,
+							},
+						},
+					}
+				} else {
+					r.Action = &route.Route_Route{
+						Route: &route.RouteAction{
+							ClusterSpecifier: &route.RouteAction_Cluster{Cluster: mRoute.Action.Cluster},
+						},
+					}
+				}
+				routes = append(routes, r)
+			}
+			vh := &route.VirtualHost{
+				Name:    mVh.Name,
+				Domains: mVh.Domains,
+				Routes:  routes,
+			}
+			virtualHosts = append(virtualHosts, vh)
+		}
+		rc := &route.RouteConfiguration{
+			Name:         mRouteConfig.Name,
+			VirtualHosts: virtualHosts,
+		}
+		resources[i] = rc
+	}
+	return resources
+}
+
+// UPDATED: Now correctly builds the router filter with its typed config.
+func makeHTTPConnectionManager(mHcm *HTTPConnectionManager, routeConfigs []types.Resource) (*hcm.HttpConnectionManager, error) {
+	// Create the router filter config. For default behavior, it's an empty object.
+	routerConfigProto, err := anypb.New(&router.Router{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal router config: %w", err)
+	}
+
+	// Create the full HttpFilter object, including the name and the typed config.
+	routerFilter := &hcm.HttpFilter{
+		Name: wellknown.Router,
+		ConfigType: &hcm.HttpFilter_TypedConfig{
+			TypedConfig: routerConfigProto,
+		},
+	}
+
+	var matchedRouteConfig *route.RouteConfiguration
+	for _, rcResource := range routeConfigs {
+		rc, ok := rcResource.(*route.RouteConfiguration)
+		if !ok {
+			continue
+		}
+		if rc.Name == mHcm.RouteConfigName {
+			matchedRouteConfig = rc
+			break
+		}
+	}
+	if matchedRouteConfig == nil {
+		return nil, fmt.Errorf("route_config_name '%s' not found", mHcm.RouteConfigName)
+	}
+
+	hcmConfig := &hcm.HttpConnectionManager{
+		StatPrefix: mHcm.StatPrefix,
+		RouteSpecifier: &hcm.HttpConnectionManager_RouteConfig{
+			RouteConfig: matchedRouteConfig,
+		},
+		HttpFilters: []*hcm.HttpFilter{
+			// Add other filters here in the future
+			routerFilter, // Add the correctly constructed router filter.
+		},
+	}
+	return hcmConfig, nil
+}
+
+// (makeListeners is unchanged, but will now receive a correctly built HCM)
+func makeListeners(manifestListeners []Listener, routeConfigs []types.Resource) ([]types.Resource, error) {
+	resources := make([]types.Resource, len(manifestListeners))
+	for i, mListener := range manifestListeners {
+		var filters []*listener.Filter
+		for _, mFilter := range mListener.Filters {
+			if mFilter.Type == "http_connection_manager" {
+				hcmConfig, err := makeHTTPConnectionManager(mFilter.HTTPConnectionManager, routeConfigs)
+				if err != nil {
+					return nil, fmt.Errorf("listener %s: %w", mListener.Name, err)
+				}
+				pbst, err := anypb.New(hcmConfig)
+				if err != nil {
+					return nil, fmt.Errorf("failed to marshal hcm config for listener %s: %w", mListener.Name, err)
+				}
+				filter := &listener.Filter{
+					Name: wellknown.HTTPConnectionManager,
+					ConfigType: &listener.Filter_TypedConfig{
+						TypedConfig: pbst,
+					},
+				}
+				filters = append(filters, filter)
+			}
+		}
+
+		l := &listener.Listener{
+			Name: mListener.Name,
+			Address: &core.Address{
+				Address: &core.Address_SocketAddress{
+					SocketAddress: &core.SocketAddress{
+						Address:       mListener.Address,
+						PortSpecifier: &core.SocketAddress_PortValue{PortValue: mListener.Port},
+					},
+				},
+			},
+			FilterChains: []*listener.FilterChain{
+				{
+					Filters: filters,
+				},
+			},
+		}
+		resources[i] = l
+	}
+	return resources, nil
+}


### PR DESCRIPTION
feat(xds-adapter): Implement and validate static manifest-to-xDS generator

This commit introduces the xds-adapter, a Go tool that translates a high-level `manifest.yaml` into a complete, Envoy-validated static bootstrap configuration.

Key changes in this implementation:

-   **Manifest-to-Protobuf Translator:** The core logic in `translator.go` converts the declarative manifest schema into v3 Protobuf resources for Clusters, RouteConfigurations, and Listeners.

-   **Static Bootstrap Generation:** The tool produces a self-contained bootstrap file by embedding `RouteConfiguration` resources directly into the `HttpConnectionManager`'s `route_config` field. This enables full, static validation via `envoy --mode validate`.

-   **Protobuf-Correct Serialization:** The output is generated using a `protojson` to `JSONToYAML` pipeline. This ensures Protobuf-correct serialization, correctly omitting zero-value fields that are invalid in a static bootstrap config.

-   **Typed Filter Configuration:** The `HttpConnectionManager` is constructed with a fully-typed router filter, satisfying the strict requirements of Envoy's configuration validator.