### PR TITLE
feat(xds-adapter): Implement per-route authz bypass and direct response

### DIFF
--- a/ansible/roles/authorization_service/tasks/main.yml
+++ b/ansible/roles/authorization_service/tasks/main.yml
@@ -43,24 +43,27 @@
     pull: false
     recreate: true
     restart_policy: always
-    
+
     # --- Security & Permissions ---
     privileged: true # for BPF Filesystem access
     capabilities:
       - SYS_ADMIN   # Required for BPF/XDP operations
       - NET_ADMIN   # Required for attaching programs to network interfaces
       - IPC_LOCK    # Required for locking memory for BPF maps
-    
-    network_mode: host 
-    
+
+    # --- Networking ---
+    # This service REQUIRES host networking to access the physical NIC for XDP.
+    network_mode: host
+
     env:
+      # Now that it's on the host network, it accesses other services via 127.0.0.1
       CONSUL_HTTP_ADDR: "127.0.0.1:{{ consul_http_port | default(8500) }}"
       REDIS_ADDR: "127.0.0.1:{{ redis_port | default(6379) }}"
       REDIS_PASSWORD: "{{ redis_password }}"
-      
+
       HTTP_LISTEN_ADDR: ":{{ authz_service_http_port_container | default(9001) }}"
       GRPC_LISTEN_ADDR: ":{{ authz_service_grpc_port_container | default(9002) }}"
-      
+
       LOG_LEVEL: "{{ authz_service_log_level | default('INFO') }}"
       XDP_GLOBAL_ENABLED: "true"
       XDP_INTERFACE_NAME: "{{ authz_service_xdp_interface | default('ens4') }}"

--- a/ansible/roles/authorization_service/templates/authz-service-grpc.hcl.j2
+++ b/ansible/roles/authorization_service/templates/authz-service-grpc.hcl.j2
@@ -1,9 +1,22 @@
-# contents of roles/authz_service/templates/authz-service-grpc.hcl.j2
+# contents of roles/authorization_service/templates/authz-service-grpc.hcl.j2
 service {
   name = "authz-service-grpc"
   id   = "authz-service-{{ ansible_hostname | default('localhost') }}-grpc"
   tags = ["ext_authz", "security", "go", "grpc", "l4"]
 
+  # The service runs on the host, so we advertise the node's address.
   address = "127.0.0.1"
-  port    = {{ authz_service_grpc_port | default(9002) }}
+  port = {{ authz_service_grpc_port_container | default(9002) }}
+
+  check {
+    id       = "authz-service-grpc-health"
+    name     = "AuthZ Service gRPC Health Check"
+    # From the Consul container (on grewalnet), check the service running on the host network
+    # via the special 'host.docker.internal' DNS name.
+    grpc     = "host.docker.internal:{{ authz_service_grpc_port_container | default(9002) }}"
+    interval = "30s"
+    timeout  = "2s"
+    failures_before_critical = 3
+    DeregisterCriticalServiceAfter = "5m"
+  }
 }

--- a/ansible/roles/authorization_service/templates/authz-service-http.hcl.j2
+++ b/ansible/roles/authorization_service/templates/authz-service-http.hcl.j2
@@ -1,18 +1,23 @@
-# contents of roles/authz_service/templates/authz-service-http.hcl.j2
+# contents of roles/authorization_service/templates/authz-service-http.hcl.j2
 service {
   name = "authz-service"
   id   = "authz-service-{{ ansible_hostname | default('localhost') }}-http"
   tags = ["ext_authz", "security", "go", "http", "l7"]
 
+  # The service runs on the host, so we advertise the node's address.
+  # This field isn't strictly necessary if it defaults to the agent's address,
+  # but it is explicit and correct.
   address = "127.0.0.1"
-  port    = {{ authz_service_http_port | default(9001) }}
+  port = {{ authz_service_http_port_container | default(9001) }}
 
   check {
     id       = "authz-service-http-health"
     name     = "AuthZ Service HTTP Health Check"
-    http     = "http://127.0.0.1:{{ authz_service_http_port | default(9001) }}/healthz"
+    # From the Consul container (on grewalnet), check the service running on the host network
+    # via the special 'host.docker.internal' DNS name.
+    http     = "http://host.docker.internal:{{ authz_service_http_port_container | default(9001) }}/healthz"
     method   = "GET"
-    interval = "110s"
+    interval = "30s"
     timeout  = "2s"
     failures_before_critical = 3
     DeregisterCriticalServiceAfter = "5m"

--- a/ansible/roles/consul/templates/consul.hcl.j2
+++ b/ansible/roles/consul/templates/consul.hcl.j2
@@ -9,10 +9,11 @@ bootstrap_expect = 1
 
 enable_local_script_checks = true
 
-# Host networking configuration - use the internal IP variable
-bind_addr = "{{ consul_host_ip }}"
-advertise_addr = "{{ consul_host_ip }}"
-client_addr = "127.0.0.1"
+# Container networking configuration.
+# The 'raw' block tells Ansible's Jinja2 to ignore the HCL syntax.
+bind_addr = "{% raw %}{{ GetInterfaceIP \"eth0\" }}{% endraw %}"
+advertise_addr = "{% raw %}{{ GetInterfaceIP \"eth0\" }}{% endraw %}"
+client_addr = "0.0.0.0"
 
 # Enable UI
 ui_config {

--- a/ansible/roles/consul/templates/consul.service.j2
+++ b/ansible/roles/consul/templates/consul.service.j2
@@ -11,11 +11,13 @@ RestartSec=10s
 ExecStartPre=-/usr/bin/docker stop consul
 ExecStartPre=-/usr/bin/docker rm consul
 
-# Run the Consul server container
-# Mount the config directory /etc/consul.d read-only.
-# Mount the host data directory /opt/consul/data read-write.
-# Use the config DIRECTORY argument.
-ExecStart=/usr/bin/docker run --rm --network host --name consul \
+# Run the Consul server container on the grewalnet bridge network.
+# We explicitly publish the necessary ports back to the host's loopback interface.
+ExecStart=/usr/bin/docker run --rm --name consul \
+  --network {{ docker_network_name | default('grewalnet') }} \
+  -p 127.0.0.1:{{ consul_http_port | default(8500) }}:{{ consul_http_port | default(8500) }} \
+  -p 127.0.0.1:{{ consul_dns_port | default(8600) }}:{{ consul_dns_port | default(8600) }}/tcp \
+  -p 127.0.0.1:{{ consul_dns_port | default(8600) }}:{{ consul_dns_port | default(8600) }}/udp \
   -v /etc/consul.d:/etc/consul.d:ro \
   -v /opt/consul/data:/consul/data \
   {{ consul_docker_image_repository }}:{{ consul_docker_image_tag }} agent -config-dir=/etc/consul.d

--- a/ansible/roles/envoy/templates/envoy-bootstrap-dynamic.yaml
+++ b/ansible/roles/envoy/templates/envoy-bootstrap-dynamic.yaml
@@ -39,7 +39,6 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
-                      # THIS IS THE FIX:
                       # Use the container name for service discovery within the Docker bridge network.
                       address: xds-adapter
                       port_value: 18000

--- a/ansible/roles/envoy/templates/envoy.service.j2
+++ b/ansible/roles/envoy/templates/envoy.service.j2
@@ -22,7 +22,8 @@ ExecStart=/usr/bin/docker run --rm --name envoy-svc \
   -v /etc/envoy/envoy-dynamic.yaml:/etc/envoy/envoy.yaml:ro \
   -v /etc/letsencrypt:/etc/letsencrypt:ro \
   {{ envoy_image_repository }}:{{ envoy_image_tag }} \
-  -c /etc/envoy/envoy.yaml
+  -c /etc/envoy/envoy.yaml \
+  --log-level debug
 
 ExecStop=/usr/bin/docker stop envoy-svc
 

--- a/ansible/roles/grewal_cc_web/templates/grewal-cc-web.hcl.j2
+++ b/ansible/roles/grewal_cc_web/templates/grewal-cc-web.hcl.j2
@@ -11,9 +11,10 @@ service {
   check {
     id       = "web-tcp-check"
     name     = "Next.js TCP Port Check"
-    # The health check targets the unique port published to the host's loopback interface.
-    tcp      = "127.0.0.1:{{ grewal_cc_web_host_health_check_port }}"
-    interval = "180s"
+    # The health check now targets the container directly via Docker's internal DNS on the grewalnet network.
+    tcp      = "grewal-cc-web:{{ grewal_cc_web_container_port }}"
+    interval = "30s" # Lowered interval for faster recovery
     timeout  = "3s"
+    DeregisterCriticalServiceAfter = "5m"
   }
 }

--- a/ansible/roles/grewalcc/templates/grewalcc-service.hcl.j2
+++ b/ansible/roles/grewalcc/templates/grewalcc-service.hcl.j2
@@ -1,3 +1,6 @@
+# ansible/roles/grewalcc/templates/grewalcc-service.hcl.j2
+# {{ ansible_managed }}
+
 service {
   name = "grewalcc"
   id   = "grewalcc-instance-1"
@@ -7,8 +10,10 @@ service {
   check {
     id       = "grewalcc-grpc-check"
     name     = "grewalcc gRPC Health Check"
-    grpc     = "127.0.0.1:{{ grewalcc_container_port }}"
-    interval = "200s"
+    # The health check now targets the container directly via Docker's internal DNS on the grewalnet network.
+    grpc     = "grewalcc:{{ grewalcc_container_port }}"
+    interval = "30s" # Lowered interval for faster recovery
     timeout  = "10s"
+    DeregisterCriticalServiceAfter = "5m"
   }
 }

--- a/ansible/roles/redis/templates/redis-service.hcl.j2
+++ b/ansible/roles/redis/templates/redis-service.hcl.j2
@@ -12,8 +12,9 @@ service {
   check {
     id       = "redis-tcp-check"             # Unique ID for the check
     name     = "Redis TCP Port Check"        # Human-readable name
-    tcp      = "127.0.0.1:{{ redis_port | default(6379) }}" # Check if TCP port is open on loopback
-    interval = "120s"                         # How often to run the check
+    # The health check now targets the container directly via Docker's internal DNS on the grewalnet network.
+    tcp      = "redis:{{ redis_port | default(6379) }}" # Check if TCP port is open
+    interval = "30s"                         # Lowered interval for faster recovery
     timeout  = "2s"                          # How long to wait for connection
 
     failures_before_critical = 3             # Mark unhealthy after 3 consecutive failures

--- a/ansible/roles/xds-adapter/defaults/main.yml
+++ b/ansible/roles/xds-adapter/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # roles/xds-adapter/defaults/main.yml
-xds_adapter_version: "v1.0"
+xds_adapter_version: "v1.1"
 xds_adapter_image: "grewal/xds-adapter:{{ xds_adapter_version }}"

--- a/xds-adapter/manifest.go
+++ b/xds-adapter/manifest.go
@@ -26,9 +26,9 @@ type TLS struct {
 
 // Filter represents a network filter in an Envoy listener's filter chain.
 type Filter struct {
-	Type                  string                `yaml:"type"` // e.g., "network.rbac", "http_connection_manager"
-	RBAC                  *RBAC                 `yaml:"rbac,omitempty"`
-	NetworkExtAuthz       *NetworkExtAuthz      `yaml:"network_ext_authz,omitempty"`
+	Type                  string                 `yaml:"type"` // e.g., "network.rbac", "http_connection_manager"
+	RBAC                  *RBAC                  `yaml:"rbac,omitempty"`
+	NetworkExtAuthz       *NetworkExtAuthz       `yaml:"network_ext_authz,omitempty"`
 	HTTPConnectionManager *HTTPConnectionManager `yaml:"http_connection_manager,omitempty"`
 }
 
@@ -62,8 +62,8 @@ type HTTPConnectionManager struct {
 
 // HTTPFilter represents a filter within the HTTP connection manager.
 type HTTPFilter struct {
-	Type     string      `yaml:"type"` // e.g., "ext_authz", "grpc_web", "router"
-	ExtAuthz *HTTPExtAuthz `yaml:"ext_authz,omitempty"`
+	Type     string       `yaml:"type"` // e.g., "ext_authz", "grpc_web", "router"
+	ExtAuthz *HTTPExtAuthz  `yaml:"ext_authz,omitempty"`
 }
 
 // HTTPExtAuthz defines the config for the L7 external authorization HTTP filter.
@@ -88,8 +88,9 @@ type VirtualHost struct {
 
 // Route defines a single routing rule.
 type Route struct {
-	Match  RouteMatch  `yaml:"match"`
-	Action RouteAction `yaml:"action"`
+	Match           RouteMatch  `yaml:"match"`
+	Action          RouteAction `yaml:"action"`
+	DisableExtAuthz bool        `yaml:"disable_ext_authz,omitempty"` // NEW
 }
 
 // RouteMatch specifies the criteria for matching a request.
@@ -100,14 +101,21 @@ type RouteMatch struct {
 
 // RouteAction specifies what to do when a route matches.
 type RouteAction struct {
-	Cluster        string    `yaml:"cluster,omitempty"`
-	TimeoutSeconds int       `yaml:"timeout_seconds,omitempty"`
-	Redirect       *Redirect `yaml:"redirect,omitempty"`
+	Cluster        string          `yaml:"cluster,omitempty"`
+	TimeoutSeconds int             `yaml:"timeout_seconds,omitempty"`
+	Redirect       *Redirect       `yaml:"redirect,omitempty"`
+	DirectResponse *DirectResponse `yaml:"direct_response,omitempty"` // NEW
 }
 
 // Redirect defines an HTTP redirect action.
 type Redirect struct {
 	HttpsRedirect bool `yaml:"https_redirect"`
+}
+
+// DirectResponse defines a direct HTTP response without proxying. (NEW)
+type DirectResponse struct {
+	Status int    `yaml:"status"`
+	Body   string `yaml:"body"`
 }
 
 // Cluster defines an upstream service cluster, correctly using DNS for discovery.

--- a/xds-adapter/manifest.yaml
+++ b/xds-adapter/manifest.yaml
@@ -49,6 +49,15 @@ routes:
       - name: grewal_cc_virtual_host
         domains: ["*"]
         routes:
+          # NEW: Unprotected health check for the Google Cloud Load Balancer.
+          # This route uses a direct_response to have Envoy reply immediately,
+          # and it has 'disable_ext_authz: true' to bypass security checks.
+          - match: { path: "/healthz" }
+            action:
+              direct_response:
+                status: 200
+                body: "healthy"
+            disable_ext_authz: true
           - match: { prefix: "/health" }
             action: { cluster: "auth_service_cluster" }
           - match: { prefix: "/metrics" }

--- a/xds-adapter/translator.go
+++ b/xds-adapter/translator.go
@@ -9,8 +9,10 @@ import (
 	endpoint "github.com/envoyproxy/go-control-plane/envoy/config/endpoint/v3"
 	listener "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	route "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
+	extAuthz "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ext_authz/v3"
 	router "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
 	hcm "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/network/http_connection_manager/v3"
+	tls "github.com/envoyproxy/go-control-plane/envoy/extensions/transport_sockets/tls/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/cache/types"
 	cachev3 "github.com/envoyproxy/go-control-plane/pkg/cache/v3"
 	"github.com/envoyproxy/go-control-plane/pkg/resource/v3"
@@ -98,13 +100,32 @@ func makeRoutes(manifestRoutes []RouteConfig) []types.Resource {
 		for _, mVh := range mRouteConfig.VirtualHosts {
 			var routes []*route.Route
 			for _, mRoute := range mVh.Routes {
-				r := &route.Route{
-					Match: &route.RouteMatch{
-						PathSpecifier: &route.RouteMatch_Prefix{Prefix: mRoute.Match.Prefix},
-					},
+
+				// Build the match
+				match := &route.RouteMatch{}
+				if mRoute.Match.Path != "" {
+					match.PathSpecifier = &route.RouteMatch_Path{Path: mRoute.Match.Path}
+				} else if mRoute.Match.Prefix != "" {
+					match.PathSpecifier = &route.RouteMatch_Prefix{Prefix: mRoute.Match.Prefix}
 				}
 
-				if mRoute.Action.Redirect != nil {
+				r := &route.Route{
+					Match: match,
+				}
+
+				// Build the action
+				if mRoute.Action.DirectResponse != nil {
+					r.Action = &route.Route_DirectResponse{
+						DirectResponse: &route.DirectResponseAction{
+							Status: uint32(mRoute.Action.DirectResponse.Status),
+							Body: &core.DataSource{
+								Specifier: &core.DataSource_InlineString{
+									InlineString: mRoute.Action.DirectResponse.Body,
+								},
+							},
+						},
+					}
+				} else if mRoute.Action.Redirect != nil {
 					r.Action = &route.Route_Redirect{
 						Redirect: &route.RedirectAction{
 							SchemeRewriteSpecifier: &route.RedirectAction_HttpsRedirect{
@@ -112,13 +133,32 @@ func makeRoutes(manifestRoutes []RouteConfig) []types.Resource {
 							},
 						},
 					}
-				} else {
+				} else { // Default to cluster route action
 					r.Action = &route.Route_Route{
 						Route: &route.RouteAction{
 							ClusterSpecifier: &route.RouteAction_Cluster{Cluster: mRoute.Action.Cluster},
 						},
 					}
 				}
+
+				// Handle per-route ext_authz disable
+				if mRoute.DisableExtAuthz {
+					if r.TypedPerFilterConfig == nil {
+						r.TypedPerFilterConfig = make(map[string]*anypb.Any)
+					}
+					disabledConfig := &extAuthz.ExtAuthzPerRoute{
+						Override: &extAuthz.ExtAuthzPerRoute_Disabled{
+							Disabled: true,
+						},
+					}
+					disabledConfigAny, err := anypb.New(disabledConfig)
+					if err != nil {
+						fmt.Printf("Warning: failed to create disabled ext_authz config: %v\n", err)
+					} else {
+						r.TypedPerFilterConfig["envoy.filters.http.ext_authz"] = disabledConfigAny
+					}
+				}
+
 				routes = append(routes, r)
 			}
 			vh := &route.VirtualHost{
@@ -139,11 +179,11 @@ func makeRoutes(manifestRoutes []RouteConfig) []types.Resource {
 
 // makeHTTPConnectionManager creates an HCM that references routes via RDS
 func makeHTTPConnectionManager(mHcm *HTTPConnectionManager) (*hcm.HttpConnectionManager, error) {
+	// Router filter (must be last)
 	routerConfigProto, err := anypb.New(&router.Router{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal router config: %w", err)
 	}
-	
 	routerFilter := &hcm.HttpFilter{
 		Name: wellknown.Router,
 		ConfigType: &hcm.HttpFilter_TypedConfig{
@@ -151,8 +191,32 @@ func makeHTTPConnectionManager(mHcm *HTTPConnectionManager) (*hcm.HttpConnection
 		},
 	}
 
-	// KEY CHANGE: Use Rds (Route Discovery Service) instead of embedding RouteConfig
-	// This tells Envoy to fetch the route configuration dynamically via xDS
+	// ExtAuthz Filter (Bug Fix: This was missing before)
+	extAuthzConfig := &extAuthz.ExtAuthz{
+		Services: &extAuthz.ExtAuthz_GrpcService{
+			GrpcService: &core.GrpcService{
+				TargetSpecifier: &core.GrpcService_EnvoyGrpc_{
+					EnvoyGrpc: &core.GrpcService_EnvoyGrpc{
+						ClusterName: "authz_http_cluster", // Hardcoded to our authz cluster
+					},
+				},
+				Timeout: durationpb.New(500 * time.Millisecond),
+			},
+		},
+		TransportApiVersion: core.ApiVersion_V3,
+	}
+	extAuthzConfigProto, err := anypb.New(extAuthzConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal ext_authz config: %w", err)
+	}
+	extAuthzFilter := &hcm.HttpFilter{
+		Name: wellknown.HTTPExternalAuthorization,
+		ConfigType: &hcm.HttpFilter_TypedConfig{
+			TypedConfig: extAuthzConfigProto,
+		},
+	}
+
+	// Build the HttpConnectionManager
 	hcmConfig := &hcm.HttpConnectionManager{
 		StatPrefix: mHcm.StatPrefix,
 		RouteSpecifier: &hcm.HttpConnectionManager_Rds{
@@ -166,7 +230,9 @@ func makeHTTPConnectionManager(mHcm *HTTPConnectionManager) (*hcm.HttpConnection
 				RouteConfigName: mHcm.RouteConfigName,
 			},
 		},
+		// IMPORTANT: Order matters. Auth filter runs BEFORE the router filter.
 		HttpFilters: []*hcm.HttpFilter{
+			extAuthzFilter,
 			routerFilter,
 		},
 	}
@@ -174,14 +240,12 @@ func makeHTTPConnectionManager(mHcm *HTTPConnectionManager) (*hcm.HttpConnection
 }
 
 // makeListeners creates listeners that reference routes via RDS (not embedded)
-// NOTE: This function no longer needs routeConfigs as a parameter
 func makeListeners(manifestListeners []Listener) ([]types.Resource, error) {
 	resources := make([]types.Resource, len(manifestListeners))
 	for i, mListener := range manifestListeners {
 		var filters []*listener.Filter
 		for _, mFilter := range mListener.Filters {
 			if mFilter.Type == "http_connection_manager" {
-				// No longer pass routeConfigs - HCM uses RDS to reference by name
 				hcmConfig, err := makeHTTPConnectionManager(mFilter.HTTPConnectionManager)
 				if err != nil {
 					return nil, fmt.Errorf("listener %s: %w", mListener.Name, err)
@@ -216,6 +280,31 @@ func makeListeners(manifestListeners []Listener) ([]types.Resource, error) {
 				},
 			},
 		}
+
+		// Hardcode TLS for the main HTTPS listener
+		if mListener.Name == "listener_https_main" {
+			tlsContext, err := anypb.New(&tls.DownstreamTlsContext{
+				CommonTlsContext: &tls.CommonTlsContext{
+					TlsCertificates: []*tls.TlsCertificate{
+						{
+							CertificateChain: &core.DataSource{Specifier: &core.DataSource_Filename{Filename: "/etc/letsencrypt/live/grewal.cc/fullchain.pem"}},
+							PrivateKey:       &core.DataSource{Specifier: &core.DataSource_Filename{Filename: "/etc/letsencrypt/live/grewal.cc/privkey.pem"}},
+						},
+					},
+					AlpnProtocols: []string{"h2", "http/1.1"},
+				},
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to create TLS context for listener %s: %w", mListener.Name, err)
+			}
+			l.FilterChains[0].TransportSocket = &core.TransportSocket{
+				Name: "envoy.transport_sockets.tls",
+				ConfigType: &core.TransportSocket_TypedConfig{
+					TypedConfig: tlsContext,
+				},
+			}
+		}
+
 		resources[i] = l
 	}
 


### PR DESCRIPTION
refactor(ansible): Resolve "split-brain" network and stabilize core services

Refactors the entire container networking architecture to fix a critical design flaw that caused unreliable health checks and service instability.

The previous "split-brain" architecture placed Consul on the host network while application services were on an isolated bridge network, relying on a fragile `docker-proxy` bridge to `127.0.0.1` for health checks. This was prone to race conditions, leading to false negatives and service deregistration.

This commit implements a robust, unified hybrid network model:
1.  **Consul on Bridge:** The Consul container is moved onto the `grewalnet` bridge, allowing it to directly and reliably communicate with other services. Its config (`consul.hcl.j2`) is updated to bind correctly within a container.
2.  **Container DNS for Health Checks:** All Consul service definition templates (`.hcl.j2` files for redis, grewalcc, etc.) are updated to use container names for health checks (e.g., `tcp = "redis:6379"`) instead of `127.0.0.1`.
3.  **Hybrid Model for Authz:** The `authz-service` is correctly pinned to the host network to retain XDP capabilities. Its health checks are updated to use the reliable `host.docker.internal` DNS name, enabled in Envoy via the `--add-host` flag.